### PR TITLE
feat: Add support for anonymous and user/password authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ cursor
   "mcpServers": {
     "nats": {
       "env": {
-        "NATS_URL": "localhost:42222",
+        "NATS_URL": "nats://localhost:42222",
         "NATS_SYS_CREDS": "<base64 of SYS account creds>"
         "NATS_A_CREDS": "<base64 of A account creds>"
       },
@@ -170,7 +170,7 @@ cursor
   "mcpServers": {
     "nats": {
       "env": {
-        "NATS_URL": "localhost:42222",
+        "NATS_URL": "nats://localhost:42222",
         "NATS_NO_AUTHENTICATION": "true"
       },
       "url": "http://localhost:8000/sse"
@@ -185,7 +185,7 @@ cursor
   "mcpServers": {
     "nats": {
       "env": {
-        "NATS_URL": "localhost:42222",
+        "NATS_URL": "nats://localhost:42222",
         "NATS_USER": "myuser",
         "NATS_PASSWORD": "mypass"
       },
@@ -206,8 +206,8 @@ If using the binary:
         "stdio"
       ],
       "env": {
-        "NATS_URL": "localhost:42222",
-        "NATS_SYS_CREDS": "<base64 of SYS account creds>"
+        "NATS_URL": "nats://localhost:42222",
+        "NATS_SYS_CREDS": "<base64 of SYS account creds>",
         "NATS_A_CREDS": "<base64 of A account creds>"
       }
     }
@@ -227,7 +227,7 @@ If using the binary:
         "--no-authentication"
       ],
       "env": {
-        "NATS_URL": "localhost:42222"
+        "NATS_URL": "nats://localhost:4222"
       }
     }
   }
@@ -244,12 +244,11 @@ If using the binary:
         "--transport",
         "stdio",
         "--user",
-        "myuser",
-        "--password",
-        "mypass"
+        "myuser"
       ],
       "env": {
-        "NATS_URL": "localhost:42222"
+        "NATS_URL": "nats://localhost:4222",
+        "NATS_PASSWORD": "mypass"
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -86,12 +86,32 @@ go build -o mcp-nats ./cmd/mcp-nats
 - `NATS_URL`: The URL of your NATS server (e.g., `localhost:4222`)
 - `NATS_<ACCOUNT>_CREDS`: Base64 encoded NATS credentials for each account
   - Example: `NATS_SYS_CREDS`, `NATS_A_CREDS`
+- `NATS_NO_AUTHENTICATION`: Set to "true" to enable anonymous connections (no credentials required)
+- `NATS_USER`: Username or token for user/password authentication
+- `NATS_PASSWORD`: Password for user/password authentication
 
 ### Command Line Flags
 - `--transport`: Transport type (stdio or sse), default: stdio
 - `--sse-address`: Address for SSE server to listen on, default: 0.0.0.0:8000
 - `--log-level`: Log level (debug, info, warn, error), default: info
 - `--json-logs`: Output logs in JSON format, default: false
+- `--no-authentication`: Allow anonymous connections without credentials
+- `--user`: NATS username or token (can also be set via NATS_USER env var)
+- `--password`: NATS password (can also be set via NATS_PASSWORD env var)
+
+### Authentication Methods
+
+The MCP NATS server supports three authentication methods:
+
+1. **Credentials-based Authentication** (default): Uses NATS credentials files
+   - Set `NATS_<ACCOUNT>_CREDS` environment variables
+   - Requires `account_name` parameter in all tools
+
+2. **User/Password Authentication**: Uses username and password
+   - Set `NATS_USER` and `NATS_PASSWORD` environment variables or use `--user` and `--password` flags
+
+3. **Anonymous Authentication**: No authentication required
+   - Set `NATS_NO_AUTHENTICATION=true` environment variable or use `--no-authentication` flag
 
 ### Example Usage
 ```sh
@@ -103,6 +123,16 @@ go build -o mcp-nats ./cmd/mcp-nats
 
 # Run with custom SSE address
 ./mcp-nats --transport sse --sse-address localhost:9000
+
+# Run with anonymous authentication
+./mcp-nats --no-authentication
+
+# Run with user/password authentication
+./mcp-nats --user myuser --password mypass
+
+# Run with environment variables for authentication
+NATS_NO_AUTHENTICATION=true ./mcp-nats
+NATS_USER=myuser NATS_PASSWORD=mypass ./mcp-nats
 ```
 
 ### Using VSCode with remote MCP server
@@ -133,6 +163,38 @@ cursor
   }
 }
 ```
+
+**Anonymous Authentication:**
+```json
+{
+  "mcpServers": {
+    "nats": {
+      "env": {
+        "NATS_URL": "localhost:42222",
+        "NATS_NO_AUTHENTICATION": "true"
+      },
+      "url": "http://localhost:8000/sse"
+    }
+  }
+}
+```
+
+**User/Password Authentication:**
+```json
+{
+  "mcpServers": {
+    "nats": {
+      "env": {
+        "NATS_URL": "localhost:42222",
+        "NATS_USER": "myuser",
+        "NATS_PASSWORD": "mypass"
+      },
+      "url": "http://localhost:8000/sse"
+    }
+  }
+}
+```
+
 If using the binary:
 ```json
 {
@@ -152,7 +214,49 @@ If using the binary:
   }
 }
 ```
-if using docker:
+
+**Anonymous Authentication with Binary:**
+```json
+{
+  "mcpServers": {
+    "nats": {
+      "command": "mcp-nats",
+      "args": [
+        "--transport",
+        "stdio",
+        "--no-authentication"
+      ],
+      "env": {
+        "NATS_URL": "localhost:42222"
+      }
+    }
+  }
+}
+```
+
+**User/Password Authentication with Binary:**
+```json
+{
+  "mcpServers": {
+    "nats": {
+      "command": "mcp-nats",
+      "args": [
+        "--transport",
+        "stdio",
+        "--user",
+        "myuser",
+        "--password",
+        "mypass"
+      ],
+      "env": {
+        "NATS_URL": "localhost:42222"
+      }
+    }
+  }
+}
+```
+
+**Docker Configuration:**
 ```json
 {
   "mcpServers": {

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -35,9 +35,9 @@ func Initialize(cfg Config) {
 	}
 
 	if cfg.JSONFormat {
-		handler = slog.NewJSONHandler(os.Stdout, opts)
+		handler = slog.NewJSONHandler(os.Stderr, opts)
 	} else {
-		handler = slog.NewTextHandler(os.Stdout, opts)
+		handler = slog.NewTextHandler(os.Stderr, opts)
 	}
 
 	defaultLogger = slog.New(handler)

--- a/tools/common/nats.go
+++ b/tools/common/nats.go
@@ -17,6 +17,213 @@ type NATSCreds struct {
 	Creds       string // base64 encoded credentials
 }
 
+// NATSAuthStrategy defines the interface for different authentication strategies
+type NATSAuthStrategy interface {
+	BuildArgs(baseURL string) []string
+	GetAccountName() string
+	Cleanup() error
+}
+
+// AnonymousAuthStrategy implements anonymous authentication
+type AnonymousAuthStrategy struct {
+	accountName string
+}
+
+func NewAnonymousAuthStrategy() *AnonymousAuthStrategy {
+	return &AnonymousAuthStrategy{
+		accountName: "anonymous",
+	}
+}
+
+func (a *AnonymousAuthStrategy) BuildArgs(baseURL string) []string {
+	return []string{"-s", baseURL}
+}
+
+func (a *AnonymousAuthStrategy) GetAccountName() string {
+	return a.accountName
+}
+
+func (a *AnonymousAuthStrategy) Cleanup() error {
+	return nil // No cleanup needed for anonymous auth
+}
+
+// UserPassAuthStrategy implements user/password authentication
+type UserPassAuthStrategy struct {
+	user        string
+	password    string
+	accountName string
+}
+
+// NewUserPassAuthStrategy creates a new UserPassAuthStrategy instance
+func NewUserPassAuthStrategy(user, password string) *UserPassAuthStrategy {
+	return &UserPassAuthStrategy{
+		user:        user,
+		password:    password,
+		accountName: fmt.Sprintf("userpass_%s", user),
+	}
+}
+
+// BuildArgs builds the arguments for the NATS CLI command
+func (u *UserPassAuthStrategy) BuildArgs(baseURL string) []string {
+	return []string{"-s", baseURL, "--user", u.user, "--password", u.password}
+}
+
+// GetAccountName returns the account name for this authentication strategy
+func (u *UserPassAuthStrategy) GetAccountName() string {
+	return u.accountName
+}
+
+// Cleanup cleans up any resources used by this authentication strategy
+func (u *UserPassAuthStrategy) Cleanup() error {
+	return nil // No cleanup needed for user/pass auth
+}
+
+// CredentialsAuthStrategy implements credentials-based authentication
+type CredentialsAuthStrategy struct {
+	creds       NATSCreds
+	credsFile   string
+	accountName string
+}
+
+// NewCredentialsAuthStrategy creates a new CredentialsAuthStrategy instance
+func NewCredentialsAuthStrategy(creds NATSCreds) (*CredentialsAuthStrategy, error) {
+	// Create temporary directory for credentials if it doesn't exist
+	tmpDir := filepath.Join(os.TempDir(), "nats-creds")
+	if err := os.MkdirAll(tmpDir, 0700); err != nil {
+		return nil, fmt.Errorf("failed to create temp directory: %v", err)
+	}
+
+	// Create temporary file for credentials
+	credsFile := filepath.Join(tmpDir, fmt.Sprintf("%s.creds", creds.AccountName))
+
+	// Decode and write base64 credentials to file
+	credsData, err := base64.StdEncoding.DecodeString(creds.Creds)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode credentials: %v", err)
+	}
+
+	if err := os.WriteFile(credsFile, credsData, 0600); err != nil {
+		return nil, fmt.Errorf("failed to write credentials file: %v", err)
+	}
+
+	logger.Debug("Created NATS credentials file",
+		"account", creds.AccountName,
+		"file", credsFile,
+	)
+
+	return &CredentialsAuthStrategy{
+		creds:       creds,
+		credsFile:   credsFile,
+		accountName: creds.AccountName,
+	}, nil
+}
+
+// BuildArgs builds the arguments for the NATS CLI command
+func (c *CredentialsAuthStrategy) BuildArgs(baseURL string) []string {
+	return []string{"-s", baseURL, "--creds", c.credsFile}
+}
+
+// GetAccountName returns the account name for this authentication strategy
+func (c *CredentialsAuthStrategy) GetAccountName() string {
+	return c.accountName
+}
+
+// Cleanup cleans up any resources used by this authentication strategy
+func (c *CredentialsAuthStrategy) Cleanup() error {
+	if c.credsFile != "" {
+		logger.Debug("Cleaning up NATS credentials file",
+			"account", c.accountName,
+			"file", c.credsFile,
+		)
+		return os.Remove(c.credsFile)
+	}
+	return nil
+}
+
+// NATSExecutor provides common NATS command execution functionality
+type NATSExecutor struct {
+	URL      string
+	Strategy NATSAuthStrategy
+	stdin    string
+}
+
+// NewNATSExecutor creates a new NATSExecutor instance with credentials
+func NewNATSExecutor(url string, creds NATSCreds) (*NATSExecutor, error) {
+	strategy, err := NewCredentialsAuthStrategy(creds)
+	if err != nil {
+		return nil, err
+	}
+
+	return &NATSExecutor{
+		URL:      url,
+		Strategy: strategy,
+	}, nil
+}
+
+// NewAnonymousNATSExecutor creates a new NATSExecutor instance for anonymous connections
+func NewAnonymousNATSExecutor(url string) *NATSExecutor {
+	return &NATSExecutor{
+		URL:      url,
+		Strategy: NewAnonymousAuthStrategy(),
+	}
+}
+
+// NewUserPassNATSExecutor creates a new NATSExecutor instance with user/password authentication
+func NewUserPassNATSExecutor(url, user, password string) *NATSExecutor {
+	return &NATSExecutor{
+		URL:      url,
+		Strategy: NewUserPassAuthStrategy(user, password),
+	}
+}
+
+// SetStdin sets the STDIN input for the next command execution
+func (e *NATSExecutor) SetStdin(input string) {
+	e.stdin = input
+}
+
+// ExecuteCommand executes a NATS CLI command with the configured authentication
+func (e *NATSExecutor) ExecuteCommand(args ...string) (string, error) {
+	baseArgs := e.Strategy.BuildArgs(e.URL)
+	args = append(baseArgs, args...)
+
+	logger.Debug("Executing NATS command",
+		"account", e.Strategy.GetAccountName(),
+		"command", strings.Join(args, " "),
+	)
+
+	cmd := exec.Command("nats", args...)
+
+	// If stdin is set, use it
+	if e.stdin != "" {
+		cmd.Stdin = strings.NewReader(e.stdin)
+		// Clear stdin after use
+		defer func() { e.stdin = "" }()
+	}
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		logger.Error("NATS command failed",
+			"error", err,
+			"output", string(output),
+			"account", e.Strategy.GetAccountName(),
+			"command", strings.Join(args, " "),
+		)
+		return "", fmt.Errorf("NATS command failed: %v, output: %s", err, string(output))
+	}
+
+	return string(output), nil
+}
+
+// Cleanup removes the temporary credentials file
+func (e *NATSExecutor) Cleanup() error {
+	return e.Strategy.Cleanup()
+}
+
+// GetAccountName returns the account name for this executor
+func (e *NATSExecutor) GetAccountName() string {
+	return e.Strategy.GetAccountName()
+}
+
 // GetCredsFromEnv gets all NATS credentials from environment variables
 // Environment variables should be in the format NATS_<ACCOUNT>_CRED
 func GetCredsFromEnv() (map[string]NATSCreds, error) {
@@ -49,93 +256,57 @@ func GetCredsFromEnv() (map[string]NATSCreds, error) {
 	return creds, nil
 }
 
-// NATSExecutor provides common NATS command execution functionality
-type NATSExecutor struct {
-	URL       string
-	Creds     NATSCreds
-	credsFile string
-	stdin     string
+// GetUserPassFromEnv gets NATS user/password from environment variables
+func GetUserPassFromEnv() (string, string) {
+	user := os.Getenv("NATS_USER")
+	password := os.Getenv("NATS_PASSWORD")
+	return user, password
 }
 
-// NewNATSExecutor creates a new NATSExecutor instance
-func NewNATSExecutor(url string, creds NATSCreds) (*NATSExecutor, error) {
-	// Create temporary directory for credentials if it doesn't exist
-	tmpDir := filepath.Join(os.TempDir(), "nats-creds")
-	if err := os.MkdirAll(tmpDir, 0700); err != nil {
-		return nil, fmt.Errorf("failed to create temp directory: %v", err)
+// GetAuthStrategy determines the current authentication strategy
+func GetAuthStrategy() string {
+	// Check for no-authentication flag
+	if os.Getenv("NATS_NO_AUTHENTICATION") == "true" {
+		return "anonymous"
 	}
 
-	// Create temporary file for credentials
-	credsFile := filepath.Join(tmpDir, fmt.Sprintf("%s.creds", creds.AccountName))
-
-	// Decode and write base64 credentials to file
-	credsData, err := base64.StdEncoding.DecodeString(creds.Creds)
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode credentials: %v", err)
+	// Check for user/password authentication
+	user, password := GetUserPassFromEnv()
+	if user != "" && password != "" {
+		return "userpass"
 	}
 
-	if err := os.WriteFile(credsFile, credsData, 0600); err != nil {
-		return nil, fmt.Errorf("failed to write credentials file: %v", err)
-	}
-
-	logger.Debug("Created NATS credentials file",
-		"account", creds.AccountName,
-		"file", credsFile,
-	)
-
-	return &NATSExecutor{
-		URL:       url,
-		Creds:     creds,
-		credsFile: credsFile,
-	}, nil
+	// Default to credentials-based authentication
+	return "credentials"
 }
 
-// SetStdin sets the STDIN input for the next command execution
-func (e *NATSExecutor) SetStdin(input string) {
-	e.stdin = input
+// IsAccountNameRequired determines if account_name is required based on auth strategy
+func IsAccountNameRequired() bool {
+	strategy := GetAuthStrategy()
+	// Only credentials-based authentication requires account_name
+	return strategy == "credentials"
 }
 
-// ExecuteCommand executes a NATS CLI command with the configured credentials
-func (e *NATSExecutor) ExecuteCommand(args ...string) (string, error) {
-	baseArgs := []string{"-s", e.URL, "--creds", e.credsFile}
-	args = append(baseArgs, args...)
-
-	logger.Debug("Executing NATS command",
-		"account", e.Creds.AccountName,
-		"command", strings.Join(args, " "),
-	)
-
-	cmd := exec.Command("nats", args...)
-
-	// If stdin is set, use it
-	if e.stdin != "" {
-		cmd.Stdin = strings.NewReader(e.stdin)
-		// Clear stdin after use
-		defer func() { e.stdin = "" }()
+// DetermineAccountName determines the account name to use based on authentication strategy and request parameters
+func DetermineAccountName(requestArgs map[string]interface{}) (string, error) {
+	if IsAccountNameRequired() {
+		// For credentials-based auth, account_name is required from request
+		accountNameVal, ok := requestArgs["account_name"].(string)
+		if !ok {
+			return "", fmt.Errorf("missing account_name")
+		}
+		return accountNameVal, nil
+	} else {
+		// For non-credentials auth, use strategy's account name
+		strategy := GetAuthStrategy()
+		switch strategy {
+		case "anonymous":
+			return "anonymous", nil
+		case "userpass":
+			user, _ := GetUserPassFromEnv()
+			return fmt.Sprintf("userpass_%s", user), nil
+		default:
+			return "default", nil
+		}
 	}
-
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		logger.Error("NATS command failed",
-			"error", err,
-			"output", string(output),
-			"account", e.Creds.AccountName,
-			"command", strings.Join(args, " "),
-		)
-		return "", fmt.Errorf("NATS command failed: %v, output: %s", err, string(output))
-	}
-
-	return string(output), nil
-}
-
-// Cleanup removes the temporary credentials file
-func (e *NATSExecutor) Cleanup() error {
-	if e.credsFile != "" {
-		logger.Debug("Cleaning up NATS credentials file",
-			"account", e.Creds.AccountName,
-			"file", e.credsFile,
-		)
-		return os.Remove(e.credsFile)
-	}
-	return nil
 }


### PR DESCRIPTION
### Description

This PR addresses issue #1 by adding support for multiple authentication methods to the MCP NATS server, making it easier to connect to NATS servers without requiring credential setup.

close #1 

### New Features
Multiple Authentication Methods:
  - Anonymous Authentication: Connect without any credentials using NATS_NO_AUTHENTICATION=true
  - User/Password Authentication: Use username/password with NATS_USER and NATS_PASSWORD environment variables
  - Credentials-based Authentication: Existing method using NATS credential files (default)
  
### Usage Examples
**Anonymous Authentication:**
```json
{
  "mcpServers": {
    "nats": {
      "command": "mcp-nats",
      "args": [
        "--transport",
        "stdio",
        "--no-authentication"
      ],
      "env": {
        "NATS_URL": "nats://localhost:4222"
      }
    }
  }
}
```
**User/Password Authentication:**
```json
{
  "mcpServers": {
    "nats": {
      "command": "mcp-nats",
      "args": [
        "--transport",
        "stdio",
        "--user",
        "myuser"
      ],
      "env": {
        "NATS_URL": "nats://localhost:4222",
        "NATS_PASSWORD": "mypass"
      }
    }
  }
}
```