### PR TITLE
Fix golangci-lint on Go 1.25 in CI and resolve lint/test compile errors

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -26,10 +26,8 @@ jobs:
           go-version: "1.25"
           cache: true
 
-      - name: Install golangci-lint
-        uses: golangci/golangci-lint-action@v3
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
         with:
           version: latest
-
-      - name: Run linters
-        run: make lint
+          install-mode: goinstall

--- a/cmd/mcp-nats/main_test.go
+++ b/cmd/mcp-nats/main_test.go
@@ -48,7 +48,7 @@ func TestCheckNATSConnectivityReachable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to listen: %v", err)
 	}
-	defer listener.Close()
+	defer func() { _ = listener.Close() }()
 
 	go func() {
 		conn, acceptErr := listener.Accept()

--- a/tools/account_test.go
+++ b/tools/account_test.go
@@ -75,13 +75,7 @@ func (s *AccountTestSuite) TestAccountInfoHandler() {
 
 	// Create a mock request with account_name
 	request := mcp.CallToolRequest{
-		Params: struct {
-			Name      string                 `json:"name"`
-			Arguments map[string]interface{} `json:"arguments,omitempty"`
-			Meta      *struct {
-				ProgressToken mcp.ProgressToken `json:"progressToken,omitempty"`
-			} `json:"_meta,omitempty"`
-		}{
+		Params: mcp.CallToolParams{
 			Name: "account_info",
 			Arguments: map[string]interface{}{
 				"account_name": "SYS", // Using SYS account which should exist by default
@@ -112,13 +106,7 @@ func (s *AccountTestSuite) TestAccountReportConnectionsHandler() {
 
 	// Create a mock request with account_name
 	request := mcp.CallToolRequest{
-		Params: struct {
-			Name      string                 `json:"name"`
-			Arguments map[string]interface{} `json:"arguments,omitempty"`
-			Meta      *struct {
-				ProgressToken mcp.ProgressToken `json:"progressToken,omitempty"`
-			} `json:"_meta,omitempty"`
-		}{
+		Params: mcp.CallToolParams{
 			Name: "account_report_connections",
 			Arguments: map[string]interface{}{
 				"account_name": "SYS",
@@ -149,13 +137,7 @@ func (s *AccountTestSuite) TestAccountReportConnectionsHandlerWithOptions() {
 
 	// Create a mock request with account_name and options
 	request := mcp.CallToolRequest{
-		Params: struct {
-			Name      string                 `json:"name"`
-			Arguments map[string]interface{} `json:"arguments,omitempty"`
-			Meta      *struct {
-				ProgressToken mcp.ProgressToken `json:"progressToken,omitempty"`
-			} `json:"_meta,omitempty"`
-		}{
+		Params: mcp.CallToolParams{
 			Name: "account_report_connections",
 			Arguments: map[string]interface{}{
 				"account_name": "SYS",
@@ -188,13 +170,7 @@ func (s *AccountTestSuite) TestAccountReportStatisticsHandler() {
 
 	// Create a mock request with account_name
 	request := mcp.CallToolRequest{
-		Params: struct {
-			Name      string                 `json:"name"`
-			Arguments map[string]interface{} `json:"arguments,omitempty"`
-			Meta      *struct {
-				ProgressToken mcp.ProgressToken `json:"progressToken,omitempty"`
-			} `json:"_meta,omitempty"`
-		}{
+		Params: mcp.CallToolParams{
 			Name: "account_report_statistics",
 			Arguments: map[string]interface{}{
 				"account_name": "SYS",
@@ -230,13 +206,7 @@ func (s *AccountTestSuite) TestAccountBackupHandler() {
 
 	// Create a mock request with account_name and target
 	request := mcp.CallToolRequest{
-		Params: struct {
-			Name      string                 `json:"name"`
-			Arguments map[string]interface{} `json:"arguments,omitempty"`
-			Meta      *struct {
-				ProgressToken mcp.ProgressToken `json:"progressToken,omitempty"`
-			} `json:"_meta,omitempty"`
-		}{
+		Params: mcp.CallToolParams{
 			Name: "account_backup",
 			Arguments: map[string]interface{}{
 				"account_name": "SYS",
@@ -280,13 +250,7 @@ func (s *AccountTestSuite) TestAccountBackupHandlerWithOptions() {
 
 	// Create a mock request with account_name, target, and various options
 	request := mcp.CallToolRequest{
-		Params: struct {
-			Name      string                 `json:"name"`
-			Arguments map[string]interface{} `json:"arguments,omitempty"`
-			Meta      *struct {
-				ProgressToken mcp.ProgressToken `json:"progressToken,omitempty"`
-			} `json:"_meta,omitempty"`
-		}{
+		Params: mcp.CallToolParams{
 			Name: "account_backup",
 			Arguments: map[string]interface{}{
 				"account_name": "SYS",
@@ -337,13 +301,7 @@ func (s *AccountTestSuite) TestAccountRestoreHandler() {
 
 	// Create a mock request with account_name and directory
 	request := mcp.CallToolRequest{
-		Params: struct {
-			Name      string                 `json:"name"`
-			Arguments map[string]interface{} `json:"arguments,omitempty"`
-			Meta      *struct {
-				ProgressToken mcp.ProgressToken `json:"progressToken,omitempty"`
-			} `json:"_meta,omitempty"`
-		}{
+		Params: mcp.CallToolParams{
 			Name: "account_restore",
 			Arguments: map[string]interface{}{
 				"account_name": "SYS",
@@ -392,13 +350,7 @@ func (s *AccountTestSuite) TestAccountRestoreHandlerWithOptions() {
 
 	// Create a mock request with account_name, directory, and options
 	request := mcp.CallToolRequest{
-		Params: struct {
-			Name      string                 `json:"name"`
-			Arguments map[string]interface{} `json:"arguments,omitempty"`
-			Meta      *struct {
-				ProgressToken mcp.ProgressToken `json:"progressToken,omitempty"`
-			} `json:"_meta,omitempty"`
-		}{
+		Params: mcp.CallToolParams{
 			Name: "account_restore",
 			Arguments: map[string]interface{}{
 				"account_name": "SYS",
@@ -437,13 +389,7 @@ func (s *AccountTestSuite) TestAccountTLSHandler() {
 
 	// Create a mock request with account_name
 	request := mcp.CallToolRequest{
-		Params: struct {
-			Name      string                 `json:"name"`
-			Arguments map[string]interface{} `json:"arguments,omitempty"`
-			Meta      *struct {
-				ProgressToken mcp.ProgressToken `json:"progressToken,omitempty"`
-			} `json:"_meta,omitempty"`
-		}{
+		Params: mcp.CallToolParams{
 			Name: "account_tls",
 			Arguments: map[string]interface{}{
 				"account_name": "SYS",
@@ -479,13 +425,7 @@ func (s *AccountTestSuite) TestAccountTLSHandlerWithOptions() {
 
 	// Create a mock request with account_name and options
 	request := mcp.CallToolRequest{
-		Params: struct {
-			Name      string                 `json:"name"`
-			Arguments map[string]interface{} `json:"arguments,omitempty"`
-			Meta      *struct {
-				ProgressToken mcp.ProgressToken `json:"progressToken,omitempty"`
-			} `json:"_meta,omitempty"`
-		}{
+		Params: mcp.CallToolParams{
 			Name: "account_tls",
 			Arguments: map[string]interface{}{
 				"account_name": "SYS",


### PR DESCRIPTION
## Summary

CI was failing because the prebuilt `golangci-lint` binary was built with Go 1.24 while `go.mod` targets Go 1.25. This PR installs the linter with `go install` so it is compiled with the same toolchain as `setup-go`.

Also fixes issues that prevented a clean `golangci-lint run` / test build after `mcp-go`’s `CallToolParams` change (`Arguments` is now `any`).

## Changes

- **CI** (`.github/workflows/go.yaml`): `golangci/golangci-lint-action@v6` with `install-mode: goinstall` and `version: latest`; drop redundant `make lint` (the action already runs `golangci-lint run`).
- **Tests** (`tools/account_test.go`): use `mcp.CallToolParams` for `CallToolRequest.Params` instead of anonymous struct literals.
- **Tests** (`cmd/mcp-nats/main_test.go`): satisfy `errcheck` for `listener.Close()` in defer.