### PR TITLE
feat: add read-only MCP mode (--read-only / MCP_NATS_READ_ONLY)

### DIFF
--- a/cmd/mcp-nats/main.go
+++ b/cmd/mcp-nats/main.go
@@ -37,6 +37,7 @@ type Config struct {
 	NoAuthentication bool
 	NATSUser         string
 	NATSPassword     string
+	ReadOnly         bool
 }
 
 // validateConfig ensures all config values are valid
@@ -170,7 +171,7 @@ func runHTTPServer(ctx context.Context, srv httpServer, addr, transportName stri
 	}
 }
 
-func newServer() (*server.MCPServer, error) {
+func newServer(readOnly bool) (*server.MCPServer, error) {
 	s := server.NewMCPServer(
 		AppName,
 		Version,
@@ -186,7 +187,7 @@ func newServer() (*server.MCPServer, error) {
 	}
 
 	// Register all NATS server tools
-	tools.RegisterTools(s, natsTools)
+	tools.RegisterTools(s, natsTools, readOnly)
 
 	return s, nil
 }
@@ -209,9 +210,13 @@ func run(ctx context.Context, cfg *Config) error {
 		}
 	}
 
-	s, err := newServer()
+	s, err := newServer(cfg.ReadOnly)
 	if err != nil {
 		return fmt.Errorf("failed to create server: %w", err)
+	}
+
+	if cfg.ReadOnly {
+		logger.Info("Read-only mode enabled; mutating tools omitted")
 	}
 
 	switch cfg.Transport {
@@ -253,6 +258,11 @@ func run(ctx context.Context, cfg *Config) error {
 	return nil
 }
 
+func envReadOnly() bool {
+	v := strings.TrimSpace(strings.ToLower(os.Getenv("MCP_NATS_READ_ONLY")))
+	return v == "1" || v == "true" || v == "yes"
+}
+
 func main() {
 	cfg := &Config{}
 
@@ -266,6 +276,7 @@ func main() {
 	flag.BoolVar(&cfg.NoAuthentication, "no-authentication", false, "Allow anonymous connections without credentials")
 	flag.StringVar(&cfg.NATSUser, "user", "", "NATS username or token (can also be set via NATS_USER env var)")
 	flag.StringVar(&cfg.NATSPassword, "password", "", "NATS password (can also be set via NATS_PASSWORD env var)")
+	flag.BoolVar(&cfg.ReadOnly, "read-only", envReadOnly(), "Omit mutating MCP tools; default from MCP_NATS_READ_ONLY (true/1/yes)")
 	flag.Parse()
 
 	// Validate configuration

--- a/cmd/mcp-nats/main_test.go
+++ b/cmd/mcp-nats/main_test.go
@@ -48,7 +48,7 @@ func TestCheckNATSConnectivityReachable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to listen: %v", err)
 	}
-	defer listener.Close()
+	defer func() { _ = listener.Close() }()
 
 	go func() {
 		conn, acceptErr := listener.Accept()

--- a/tools/account_test.go
+++ b/tools/account_test.go
@@ -75,15 +75,9 @@ func (s *AccountTestSuite) TestAccountInfoHandler() {
 
 	// Create a mock request with account_name
 	request := mcp.CallToolRequest{
-		Params: struct {
-			Name      string                 `json:"name"`
-			Arguments map[string]interface{} `json:"arguments,omitempty"`
-			Meta      *struct {
-				ProgressToken mcp.ProgressToken `json:"progressToken,omitempty"`
-			} `json:"_meta,omitempty"`
-		}{
+		Params: mcp.CallToolParams{
 			Name: "account_info",
-			Arguments: map[string]interface{}{
+			Arguments: map[string]any{
 				"account_name": "SYS", // Using SYS account which should exist by default
 			},
 		},
@@ -112,15 +106,9 @@ func (s *AccountTestSuite) TestAccountReportConnectionsHandler() {
 
 	// Create a mock request with account_name
 	request := mcp.CallToolRequest{
-		Params: struct {
-			Name      string                 `json:"name"`
-			Arguments map[string]interface{} `json:"arguments,omitempty"`
-			Meta      *struct {
-				ProgressToken mcp.ProgressToken `json:"progressToken,omitempty"`
-			} `json:"_meta,omitempty"`
-		}{
+		Params: mcp.CallToolParams{
 			Name: "account_report_connections",
-			Arguments: map[string]interface{}{
+			Arguments: map[string]any{
 				"account_name": "SYS",
 			},
 		},
@@ -149,15 +137,9 @@ func (s *AccountTestSuite) TestAccountReportConnectionsHandlerWithOptions() {
 
 	// Create a mock request with account_name and options
 	request := mcp.CallToolRequest{
-		Params: struct {
-			Name      string                 `json:"name"`
-			Arguments map[string]interface{} `json:"arguments,omitempty"`
-			Meta      *struct {
-				ProgressToken mcp.ProgressToken `json:"progressToken,omitempty"`
-			} `json:"_meta,omitempty"`
-		}{
+		Params: mcp.CallToolParams{
 			Name: "account_report_connections",
-			Arguments: map[string]interface{}{
+			Arguments: map[string]any{
 				"account_name": "SYS",
 				"sort":         "subs",
 				"top":          float64(10),
@@ -188,15 +170,9 @@ func (s *AccountTestSuite) TestAccountReportStatisticsHandler() {
 
 	// Create a mock request with account_name
 	request := mcp.CallToolRequest{
-		Params: struct {
-			Name      string                 `json:"name"`
-			Arguments map[string]interface{} `json:"arguments,omitempty"`
-			Meta      *struct {
-				ProgressToken mcp.ProgressToken `json:"progressToken,omitempty"`
-			} `json:"_meta,omitempty"`
-		}{
+		Params: mcp.CallToolParams{
 			Name: "account_report_statistics",
-			Arguments: map[string]interface{}{
+			Arguments: map[string]any{
 				"account_name": "SYS",
 			},
 		},
@@ -230,15 +206,9 @@ func (s *AccountTestSuite) TestAccountBackupHandler() {
 
 	// Create a mock request with account_name and target
 	request := mcp.CallToolRequest{
-		Params: struct {
-			Name      string                 `json:"name"`
-			Arguments map[string]interface{} `json:"arguments,omitempty"`
-			Meta      *struct {
-				ProgressToken mcp.ProgressToken `json:"progressToken,omitempty"`
-			} `json:"_meta,omitempty"`
-		}{
+		Params: mcp.CallToolParams{
 			Name: "account_backup",
-			Arguments: map[string]interface{}{
+			Arguments: map[string]any{
 				"account_name": "SYS",
 				"target":       tempDir,
 				"force":        true, // Use force to avoid prompts in tests
@@ -280,15 +250,9 @@ func (s *AccountTestSuite) TestAccountBackupHandlerWithOptions() {
 
 	// Create a mock request with account_name, target, and various options
 	request := mcp.CallToolRequest{
-		Params: struct {
-			Name      string                 `json:"name"`
-			Arguments map[string]interface{} `json:"arguments,omitempty"`
-			Meta      *struct {
-				ProgressToken mcp.ProgressToken `json:"progressToken,omitempty"`
-			} `json:"_meta,omitempty"`
-		}{
+		Params: mcp.CallToolParams{
 			Name: "account_backup",
-			Arguments: map[string]interface{}{
+			Arguments: map[string]any{
 				"account_name": "SYS",
 				"target":       tempDir,
 				"check":        true,
@@ -337,15 +301,9 @@ func (s *AccountTestSuite) TestAccountRestoreHandler() {
 
 	// Create a mock request with account_name and directory
 	request := mcp.CallToolRequest{
-		Params: struct {
-			Name      string                 `json:"name"`
-			Arguments map[string]interface{} `json:"arguments,omitempty"`
-			Meta      *struct {
-				ProgressToken mcp.ProgressToken `json:"progressToken,omitempty"`
-			} `json:"_meta,omitempty"`
-		}{
+		Params: mcp.CallToolParams{
 			Name: "account_restore",
-			Arguments: map[string]interface{}{
+			Arguments: map[string]any{
 				"account_name": "SYS",
 				"directory":    backupDir,
 			},
@@ -392,19 +350,13 @@ func (s *AccountTestSuite) TestAccountRestoreHandlerWithOptions() {
 
 	// Create a mock request with account_name, directory, and options
 	request := mcp.CallToolRequest{
-		Params: struct {
-			Name      string                 `json:"name"`
-			Arguments map[string]interface{} `json:"arguments,omitempty"`
-			Meta      *struct {
-				ProgressToken mcp.ProgressToken `json:"progressToken,omitempty"`
-			} `json:"_meta,omitempty"`
-		}{
+		Params: mcp.CallToolParams{
 			Name: "account_restore",
-			Arguments: map[string]interface{}{
+			Arguments: map[string]any{
 				"account_name": "SYS",
 				"directory":    backupDir,
 				"cluster":      "test-cluster",
-				"tags":         []interface{}{"tag1", "tag2"},
+				"tags":         []any{"tag1", "tag2"},
 			},
 		},
 	}
@@ -437,15 +389,9 @@ func (s *AccountTestSuite) TestAccountTLSHandler() {
 
 	// Create a mock request with account_name
 	request := mcp.CallToolRequest{
-		Params: struct {
-			Name      string                 `json:"name"`
-			Arguments map[string]interface{} `json:"arguments,omitempty"`
-			Meta      *struct {
-				ProgressToken mcp.ProgressToken `json:"progressToken,omitempty"`
-			} `json:"_meta,omitempty"`
-		}{
+		Params: mcp.CallToolParams{
 			Name: "account_tls",
-			Arguments: map[string]interface{}{
+			Arguments: map[string]any{
 				"account_name": "SYS",
 			},
 		},
@@ -479,15 +425,9 @@ func (s *AccountTestSuite) TestAccountTLSHandlerWithOptions() {
 
 	// Create a mock request with account_name and options
 	request := mcp.CallToolRequest{
-		Params: struct {
-			Name      string                 `json:"name"`
-			Arguments map[string]interface{} `json:"arguments,omitempty"`
-			Meta      *struct {
-				ProgressToken mcp.ProgressToken `json:"progressToken,omitempty"`
-			} `json:"_meta,omitempty"`
-		}{
+		Params: mcp.CallToolParams{
 			Name: "account_tls",
-			Arguments: map[string]interface{}{
+			Arguments: map[string]any{
 				"account_name": "SYS",
 				"expire_warn":  "1w",
 				"ocsp":         true,

--- a/tools/nats.go
+++ b/tools/nats.go
@@ -129,3 +129,30 @@ func (n *NATSServerTools) RTTTools() ToolCategory {
 func (n *NATSServerTools) ObjectTools() ToolCategory {
 	return n.objectTools
 }
+
+// toolCategories returns all tool categories in registration order.
+func (n *NATSServerTools) toolCategories() []ToolCategory {
+	return []ToolCategory{
+		n.ServerTools(),
+		n.StreamTools(),
+		n.KVTools(),
+		n.PublishTools(),
+		n.AccountTools(),
+		n.RTTTools(),
+		n.ObjectTools(),
+	}
+}
+
+// ToolCount returns how many tools would be registered for the given readOnly flag.
+func ToolCount(n *NATSServerTools, readOnly bool) int {
+	count := 0
+	for _, category := range n.toolCategories() {
+		for _, tool := range category.GetTools() {
+			if readOnly && IsMutatingTool(tool.Tool.Name) {
+				continue
+			}
+			count++
+		}
+	}
+	return count
+}

--- a/tools/readonly.go
+++ b/tools/readonly.go
@@ -1,0 +1,37 @@
+package tools
+
+// Mutating tools change JetStream/KV/object state, publish messages, or perform
+// account backup/restore (filesystem / cluster mutation). When adding a new
+// tool that performs writes, register its name here and keep mutatingToolNames
+// in sync.
+var mutatingToolNames = map[string]struct{}{
+	"publish": {},
+
+	"kv_add":     {},
+	"kv_put":     {},
+	"kv_create":  {},
+	"kv_update":  {},
+	"kv_del":     {},
+	"kv_purge":   {},
+	"kv_compact": {},
+
+	"object_add":  {},
+	"object_put":  {},
+	"object_del":  {},
+	"object_seal": {},
+
+	"account_backup":  {},
+	"account_restore": {},
+}
+
+// IsMutatingTool reports whether the named MCP tool mutates NATS/JetStream
+// state, publishes data, or writes local backup output.
+func IsMutatingTool(name string) bool {
+	_, ok := mutatingToolNames[name]
+	return ok
+}
+
+// MutatingToolCount returns the number of registered mutating tool names.
+func MutatingToolCount() int {
+	return len(mutatingToolNames)
+}

--- a/tools/readonly_test.go
+++ b/tools/readonly_test.go
@@ -1,0 +1,58 @@
+package tools
+
+import "testing"
+
+func TestIsMutatingTool_mutatingSet(t *testing.T) {
+	for name := range mutatingToolNames {
+		if !IsMutatingTool(name) {
+			t.Errorf("IsMutatingTool(%q) = false, want true", name)
+		}
+	}
+}
+
+func TestIsMutatingTool_readOnlySafe(t *testing.T) {
+	safe := []string{
+		"stream_list",
+		"kv_get",
+		"account_info",
+		"server_list",
+		"rtt",
+		"object_ls",
+	}
+	for _, name := range safe {
+		if IsMutatingTool(name) {
+			t.Errorf("IsMutatingTool(%q) = true, want false", name)
+		}
+	}
+}
+
+func TestMutatingToolCount(t *testing.T) {
+	if got, want := MutatingToolCount(), len(mutatingToolNames); got != want {
+		t.Fatalf("MutatingToolCount() = %d, want %d", got, want)
+	}
+}
+
+func TestToolCount_readOnlySkipsMutating(t *testing.T) {
+	n, err := NewNATSServerTools()
+	if err != nil {
+		t.Fatalf("NewNATSServerTools: %v", err)
+	}
+
+	full := ToolCount(n, false)
+	readOnly := ToolCount(n, true)
+	if got := full - readOnly; got != MutatingToolCount() {
+		t.Fatalf("full - readOnly = %d, want MutatingToolCount() = %d", got, MutatingToolCount())
+	}
+
+	seen := make(map[string]int)
+	for _, cat := range n.toolCategories() {
+		for _, tool := range cat.GetTools() {
+			seen[tool.Tool.Name]++
+		}
+	}
+	for name := range mutatingToolNames {
+		if seen[name] != 1 {
+			t.Fatalf("mutating tool %q appears %d times in catalog, want 1", name, seen[name])
+		}
+	}
+}

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -21,23 +21,14 @@ func (t *Tool) Register(mcp *server.MCPServer) {
 	mcp.AddTool(t.Tool, t.Handler)
 }
 
-// RegisterTools registers all tools from all categories with the MCP server
-func RegisterTools(mcp *server.MCPServer, n *NATSServerTools) {
-	// Define tool categories
-	categories := []ToolCategory{
-		n.ServerTools(),
-		n.StreamTools(),
-		n.KVTools(),
-		n.PublishTools(),
-		n.AccountTools(),
-		n.RTTTools(),
-		n.ObjectTools(),
-		// Add new categories here as needed
-	}
-
-	// Register all tools from each category
-	for _, category := range categories {
+// RegisterTools registers all tools from all categories with the MCP server.
+// When readOnly is true, mutating tools (see IsMutatingTool) are not registered.
+func RegisterTools(mcp *server.MCPServer, n *NATSServerTools, readOnly bool) {
+	for _, category := range n.toolCategories() {
 		for _, tool := range category.GetTools() {
+			if readOnly && IsMutatingTool(tool.Tool.Name) {
+				continue
+			}
 			tool.Register(mcp)
 		}
 	}


### PR DESCRIPTION
## Summary

Adds a server-wide **read-only mode** that **does not register** mutating MCP tools, so clients never see them in `tools/list`. Intended for safer inspection of NATS/JetStream without publish, KV/object writes, or account backup/restore.

## Configuration

- **CLI:** `--read-only`
- **Env (default for the flag when unset):** `MCP_NATS_READ_ONLY` — treated as true for `1`, `true`, or `yes` (case-insensitive)
- **Override env:** `--read-only=false`

Startup logs: `Read-only mode enabled; mutating tools omitted` when enabled.

## Mutating tools (omitted in read-only)

- `publish`
- KV: `kv_add`, `kv_put`, `kv_create`, `kv_update`, `kv_del`, `kv_purge`, `kv_compact`
- Object: `object_add`, `object_put`, `object_del`, `object_seal`
- Account: `account_backup`, `account_restore`

New write tools must add their name to `tools/readonly.go` (`mutatingToolNames`).

## Tests

- `tools/readonly_test.go`: mutating set, safe tool names, `ToolCount` vs full catalog, each mutating tool appears exactly once

## Other changes

- **account tests:** use `mcp.CallToolParams` / `map[string]any` for compatibility with current `mcp-go` `CallToolRequest` shape
- **main_test:** satisfy `errcheck` for `listener.Close()`

## How to test

```bash
go test ./...
golangci-lint run ./...
./mcp-nats --read-only --transport stdio   # mutating tools absent from list