### PR TITLE
Fix multi-arch Docker image: cross-compile NATS CLI for target platform

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,6 @@ on:
   push:
     tags:
       - "v*"
-    # TEMPORARY: remove this branches block (and branch_test below) after merging bugfix/multi-arch-nats-exec-error
-    branches:
-      - bugfix/multi-arch-nats-exec-error
 
 permissions:
   contents: read
@@ -33,7 +30,6 @@ jobs:
       image: ${{ steps.meta.outputs.image }}
       chart_ref: ${{ steps.meta.outputs.chart_ref }}
       publish: ${{ steps.meta.outputs.publish }}
-      branch_test: ${{ steps.meta.outputs.branch_test }}
       owner_lc: ${{ steps.meta.outputs.owner_lc }}
     steps:
       - name: Checkout
@@ -79,19 +75,12 @@ jobs:
             fi
           fi
 
-          # TEMPORARY: remove with branches trigger above after merge
-          branch_test="false"
-          if [[ "${GITHUB_REF}" == "refs/heads/bugfix/multi-arch-nats-exec-error" ]]; then
-            branch_test="true"
-          fi
-
           {
             echo "chart_version=${chart_version}"
             echo "app_version=${app_version}"
             echo "image=${image}"
             echo "chart_ref=${chart_ref}"
             echo "publish=${publish}"
-            echo "branch_test=${branch_test}"
             echo "owner_lc=${owner_lc}"
           } >> "${GITHUB_OUTPUT}"
 
@@ -104,7 +93,6 @@ jobs:
             echo "- image: \`${{ steps.meta.outputs.image }}\`"
             echo "- chart: \`${{ steps.meta.outputs.chart_ref }}\`"
             echo "- publish mode: \`${{ steps.meta.outputs.publish }}\`"
-            echo "- branch test image push (TEMPORARY): \`${{ steps.meta.outputs.branch_test }}\`"
           } >> "${GITHUB_STEP_SUMMARY}"
 
   image:
@@ -123,7 +111,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to GHCR
-        if: needs.prepare.outputs.publish == 'true' || needs.prepare.outputs.branch_test == 'true'
+        if: needs.prepare.outputs.publish == 'true'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -136,10 +124,8 @@ jobs:
         with:
           images: ${{ needs.prepare.outputs.image }}
           tags: |
-            type=raw,value=${{ needs.prepare.outputs.chart_version }},enable=${{ needs.prepare.outputs.branch_test != 'true' }}
-            type=raw,value=latest,enable=${{ needs.prepare.outputs.publish == 'true' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') }}
-            type=raw,value=bugfix-multi-arch-nats-exec-error,enable=${{ needs.prepare.outputs.branch_test == 'true' }}
-            type=sha,prefix=bugfix-multi-arch-,format=short,enable=${{ needs.prepare.outputs.branch_test == 'true' }}
+            type=raw,value=${{ needs.prepare.outputs.chart_version }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') }}
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.version=${{ needs.prepare.outputs.chart_version }}
@@ -150,7 +136,7 @@ jobs:
           context: .
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: ${{ needs.prepare.outputs.publish == 'true' || needs.prepare.outputs.branch_test == 'true' }}
+          push: ${{ needs.prepare.outputs.publish == 'true' }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
           provenance: false
@@ -160,7 +146,6 @@ jobs:
           {
             echo "## Container image"
             echo "- publish: \`${{ needs.prepare.outputs.publish }}\`"
-            echo "- branch test push (TEMPORARY): \`${{ needs.prepare.outputs.branch_test }}\`"
             echo "- tags:"
             echo "${{ steps.docker_meta.outputs.tags }}" | sed 's/^/  - `/' | sed 's/$/`/'
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,9 @@ on:
   push:
     tags:
       - "v*"
+    # TEMPORARY: remove this branches block (and branch_test below) after merging bugfix/multi-arch-nats-exec-error
+    branches:
+      - bugfix/multi-arch-nats-exec-error
 
 permissions:
   contents: read
@@ -30,6 +33,7 @@ jobs:
       image: ${{ steps.meta.outputs.image }}
       chart_ref: ${{ steps.meta.outputs.chart_ref }}
       publish: ${{ steps.meta.outputs.publish }}
+      branch_test: ${{ steps.meta.outputs.branch_test }}
       owner_lc: ${{ steps.meta.outputs.owner_lc }}
     steps:
       - name: Checkout
@@ -75,12 +79,19 @@ jobs:
             fi
           fi
 
+          # TEMPORARY: remove with branches trigger above after merge
+          branch_test="false"
+          if [[ "${GITHUB_REF}" == "refs/heads/bugfix/multi-arch-nats-exec-error" ]]; then
+            branch_test="true"
+          fi
+
           {
             echo "chart_version=${chart_version}"
             echo "app_version=${app_version}"
             echo "image=${image}"
             echo "chart_ref=${chart_ref}"
             echo "publish=${publish}"
+            echo "branch_test=${branch_test}"
             echo "owner_lc=${owner_lc}"
           } >> "${GITHUB_OUTPUT}"
 
@@ -93,6 +104,7 @@ jobs:
             echo "- image: \`${{ steps.meta.outputs.image }}\`"
             echo "- chart: \`${{ steps.meta.outputs.chart_ref }}\`"
             echo "- publish mode: \`${{ steps.meta.outputs.publish }}\`"
+            echo "- branch test image push (TEMPORARY): \`${{ steps.meta.outputs.branch_test }}\`"
           } >> "${GITHUB_STEP_SUMMARY}"
 
   image:
@@ -111,7 +123,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to GHCR
-        if: needs.prepare.outputs.publish == 'true'
+        if: needs.prepare.outputs.publish == 'true' || needs.prepare.outputs.branch_test == 'true'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -124,8 +136,10 @@ jobs:
         with:
           images: ${{ needs.prepare.outputs.image }}
           tags: |
-            type=raw,value=${{ needs.prepare.outputs.chart_version }}
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') }}
+            type=raw,value=${{ needs.prepare.outputs.chart_version }},enable=${{ needs.prepare.outputs.branch_test != 'true' }}
+            type=raw,value=latest,enable=${{ needs.prepare.outputs.publish == 'true' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') }}
+            type=raw,value=bugfix-multi-arch-nats-exec-error,enable=${{ needs.prepare.outputs.branch_test == 'true' }}
+            type=sha,prefix=bugfix-multi-arch-,format=short,enable=${{ needs.prepare.outputs.branch_test == 'true' }}
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.version=${{ needs.prepare.outputs.chart_version }}
@@ -136,7 +150,7 @@ jobs:
           context: .
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: ${{ needs.prepare.outputs.publish == 'true' }}
+          push: ${{ needs.prepare.outputs.publish == 'true' || needs.prepare.outputs.branch_test == 'true' }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
           provenance: false
@@ -146,6 +160,7 @@ jobs:
           {
             echo "## Container image"
             echo "- publish: \`${{ needs.prepare.outputs.publish }}\`"
+            echo "- branch test push (TEMPORARY): \`${{ needs.prepare.outputs.branch_test }}\`"
             echo "- tags:"
             echo "${{ steps.docker_meta.outputs.tags }}" | sed 's/^/  - `/' | sed 's/$/`/'
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,14 @@ ARG TARGETARCH
 # Build the application with proper cross-compilation
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -installsuffix cgo -o mcp-nats ./cmd/mcp-nats
 
-# Install NATS CLI
-RUN go install github.com/nats-io/natscli/nats@latest
+# NATS CLI: build for TARGETOS/TARGETARCH so it matches the app on multi-arch (builder runs on BUILDPLATFORM).
+# go install emits $GOPATH/bin/${GOOS}_${GOARCH}/nats when cross-compiling, else $GOPATH/bin/nats.
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go install github.com/nats-io/natscli/nats@latest && \
+    if [ -f "/go/bin/${TARGETOS}_${TARGETARCH}/nats" ]; then \
+      cp "/go/bin/${TARGETOS}_${TARGETARCH}/nats" /app/nats; \
+    else \
+      cp /go/bin/nats /app/nats; \
+    fi
 
 # Final stage
 FROM debian:bookworm-slim
@@ -36,7 +42,7 @@ WORKDIR /app
 
 # Copy the binary from the builder stage
 COPY --from=builder --chown=1000:1000 /app/mcp-nats /app/
-COPY --from=builder --chown=1000:1000 /go/bin/nats /usr/local/bin/
+COPY --from=builder --chown=1000:1000 /app/nats /usr/local/bin/nats
 
 # Use the non-root user
 USER mcp-nats

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ lint:  ## Lint the Go code.
 
 .PHONY: run
 run: ## Run the MCP server in stdio mode.
-	go run ./cmd/mcp-nats
+	go run ./cmd/mcp-nats --transport stdio
 
 .PHONY: run-sse
 run-sse: ## Run with debug level and JSON format

--- a/README.md
+++ b/README.md
@@ -259,8 +259,8 @@ cursor
   "mcpServers": {
     "nats": {
       "env": {
-        "NATS_URL": "nats://localhost:42222",
-        "NATS_SYS_CREDS": "<base64 of SYS account creds>"
+        "NATS_URL": "nats://localhost:4222",
+        "NATS_SYS_CREDS": "<base64 of SYS account creds>",
         "NATS_A_CREDS": "<base64 of A account creds>"
       },
       "url": "http://localhost:8000/mcp"
@@ -275,7 +275,7 @@ cursor
   "mcpServers": {
     "nats": {
       "env": {
-        "NATS_URL": "nats://localhost:42222",
+        "NATS_URL": "nats://localhost:4222",
         "NATS_NO_AUTHENTICATION": "true"
       },
       "url": "http://localhost:8000/mcp"
@@ -290,7 +290,7 @@ cursor
   "mcpServers": {
     "nats": {
       "env": {
-        "NATS_URL": "nats://localhost:42222",
+        "NATS_URL": "nats://localhost:4222",
         "NATS_USER": "myuser",
         "NATS_PASSWORD": "mypass"
       },
@@ -311,7 +311,7 @@ If using the binary:
         "stdio"
       ],
       "env": {
-        "NATS_URL": "nats://localhost:42222",
+        "NATS_URL": "nats://localhost:4222",
         "NATS_SYS_CREDS": "<base64 of SYS account creds>",
         "NATS_A_CREDS": "<base64 of A account creds>"
       }

--- a/cmd/mcp-nats/transport_integration_test.go
+++ b/cmd/mcp-nats/transport_integration_test.go
@@ -1,0 +1,269 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/sinadarbouy/mcp-nats/test/utils/containers"
+)
+
+func buildMCPBinary(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	cmdDir := filepath.Dir(file)
+	out := filepath.Join(t.TempDir(), "mcp-nats"+exeSuffix())
+	build := exec.Command("go", "build", "-o", out, ".")
+	build.Dir = cmdDir
+	build.Env = os.Environ()
+	if outBytes, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("go build: %v\n%s", err, outBytes)
+	}
+	return out
+}
+
+func exeSuffix() string {
+	if runtime.GOOS == "windows" {
+		return ".exe"
+	}
+	return ""
+}
+
+func natsURLFromContainer(c *containers.NatsContainer) string {
+	// c.Port is docker/nat.Port; String() includes "/tcp" which breaks nats URLs.
+	return fmt.Sprintf("nats://%s:%s", c.Host, c.Port.Port())
+}
+
+func waitHTTPStatus(t *testing.T, url string, want int, d time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		if err != nil {
+			lastErr = err
+			time.Sleep(50 * time.Millisecond)
+			continue
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			lastErr = err
+			time.Sleep(50 * time.Millisecond)
+			continue
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+		if resp.StatusCode == want {
+			return
+		}
+		lastErr = fmt.Errorf("status %d", resp.StatusCode)
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("GET %s: want status %d: %v", url, want, lastErr)
+}
+
+func mcpInitRequest() mcp.InitializeRequest {
+	req := mcp.InitializeRequest{}
+	req.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
+	req.Params.ClientInfo = mcp.Implementation{
+		Name:    "mcp-nats-transport-integration",
+		Version: "1.0.0",
+	}
+	req.Params.Capabilities = mcp.ClientCapabilities{}
+	return req
+}
+
+func assertMCPSmoke(ctx context.Context, t *testing.T, c *client.Client) {
+	t.Helper()
+	if _, err := c.Initialize(ctx, mcpInitRequest()); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	tools, err := c.ListTools(ctx, mcp.ListToolsRequest{})
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	if tools == nil || len(tools.Tools) == 0 {
+		t.Fatal("expected non-empty tool list")
+	}
+	// Server tools use $SYS and need a system account; publish works with anonymous auth.
+	callReq := mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name: "publish",
+			Arguments: map[string]any{
+				"subject": "mcp.integration.smoke",
+				"body":    "ok",
+				"count":   1,
+			},
+		},
+	}
+	res, err := c.CallTool(ctx, callReq)
+	if err != nil {
+		t.Fatalf("CallTool publish: %v", err)
+	}
+	if res == nil || res.IsError {
+		t.Fatalf("publish: IsError=%v result=%+v", res != nil && res.IsError, res)
+	}
+	if len(res.Content) == 0 {
+		t.Fatal("publish: empty content")
+	}
+}
+
+// TestMCPTransports_Integration runs MCP initialize, tools/list, and server_list over
+// streamable-http, SSE, and stdio against a real NATS testcontainer and a subprocess
+// mcp-nats binary (requires Docker).
+func TestMCPTransports_Integration(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	natsC := containers.NewNatsContainer(ctx, t)
+	t.Cleanup(func() {
+		_ = natsC.Container.Terminate(context.Background())
+	})
+	nURL := natsURLFromContainer(natsC)
+	bin := buildMCPBinary(t)
+
+	t.Run("streamable-http", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(ctx, 90*time.Second)
+		defer cancel()
+
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		addr := ln.Addr().String()
+		_ = ln.Close()
+
+		cmdCtx, cmdCancel := context.WithCancel(ctx)
+		defer cmdCancel()
+		cmd := exec.CommandContext(cmdCtx, bin,
+			"--transport", "streamable-http",
+			"--address", addr,
+			"--endpoint-path", "/mcp",
+			"--log-level", "error",
+		)
+		cmd.Env = append(os.Environ(),
+			"NATS_URL="+nURL,
+			"NATS_NO_AUTHENTICATION=true",
+		)
+		var stderr []byte
+		cmd.Stderr = &stderrWriter{&stderr}
+		if err := cmd.Start(); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() {
+			cmdCancel()
+			_ = cmd.Wait()
+			if t.Failed() && len(stderr) > 0 {
+				t.Logf("mcp-nats stderr:\n%s", stderr)
+			}
+		})
+
+		base := "http://" + addr
+		waitHTTPStatus(t, base+"/livez", http.StatusOK, 30*time.Second)
+		waitHTTPStatus(t, base+"/readyz", http.StatusOK, 30*time.Second)
+
+		httpClient, err := client.NewStreamableHttpClient(base + "/mcp")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = httpClient.Close() }()
+		if err := httpClient.Start(ctx); err != nil {
+			t.Fatalf("client Start: %v", err)
+		}
+		assertMCPSmoke(ctx, t, httpClient)
+	})
+
+	t.Run("sse", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(ctx, 90*time.Second)
+		defer cancel()
+
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		addr := ln.Addr().String()
+		_ = ln.Close()
+
+		cmdCtx, cmdCancel := context.WithCancel(ctx)
+		defer cmdCancel()
+		cmd := exec.CommandContext(cmdCtx, bin,
+			"--transport", "sse",
+			"--address", addr,
+			"--log-level", "error",
+		)
+		cmd.Env = append(os.Environ(),
+			"NATS_URL="+nURL,
+			"NATS_NO_AUTHENTICATION=true",
+		)
+		var stderr []byte
+		cmd.Stderr = &stderrWriter{&stderr}
+		if err := cmd.Start(); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() {
+			cmdCancel()
+			_ = cmd.Wait()
+			if t.Failed() && len(stderr) > 0 {
+				t.Logf("mcp-nats stderr:\n%s", stderr)
+			}
+		})
+
+		base := "http://" + addr
+		waitHTTPStatus(t, base+"/livez", http.StatusOK, 30*time.Second)
+		waitHTTPStatus(t, base+"/readyz", http.StatusOK, 30*time.Second)
+
+		sseClient, err := client.NewSSEMCPClient(base + "/sse")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = sseClient.Close() }()
+		if err := sseClient.Start(ctx); err != nil {
+			t.Fatalf("client Start: %v", err)
+		}
+		assertMCPSmoke(ctx, t, sseClient)
+	})
+
+	t.Run("stdio", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(ctx, 90*time.Second)
+		defer cancel()
+
+		env := append(os.Environ(),
+			"NATS_URL="+nURL,
+			"NATS_NO_AUTHENTICATION=true",
+		)
+		stdioClient, err := client.NewStdioMCPClient(bin, env,
+			"--transport", "stdio",
+			"--log-level", "error",
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = stdioClient.Close() }()
+		if err := stdioClient.Start(ctx); err != nil {
+			t.Fatalf("client Start: %v", err)
+		}
+		assertMCPSmoke(ctx, t, stdioClient)
+	})
+}
+
+type stderrWriter struct {
+	b *[]byte
+}
+
+func (w *stderrWriter) Write(p []byte) (int, error) {
+	*w.b = append(*w.b, p...)
+	return len(p), nil
+}

--- a/deploy/charts/mcp-nats/values.yaml
+++ b/deploy/charts/mcp-nats/values.yaml
@@ -174,8 +174,14 @@ lifecycle:
         - /bin/sh
         - -c
         - sleep 5
-volumeMounts: []
-volumes: []
+
+# Writable /tmp when readOnlyRootFilesystem is true (NATS credential temp files).
+volumeMounts:
+  - name: tmp
+    mountPath: /tmp
+volumes:
+  - name: tmp
+    emptyDir: {}
 initContainers: []
 extraInitContainers: []
 extraContainers: []

--- a/tools/account_test.go
+++ b/tools/account_test.go
@@ -42,10 +42,10 @@ func (s *AccountTestSuite) SetupSuite() {
 	// Start NATS container
 	s.natsContainer = containers.NewNatsContainer(s.ctx, s.T())
 
-	// Get NATS URL
+	// Get NATS URL (use Port.Port() — nat.Port.String() includes "/tcp")
 	natsHost := s.natsContainer.Host
 	natsPort := s.natsContainer.Port
-	s.natsURL = fmt.Sprintf("nats://%s:%s", natsHost, natsPort)
+	s.natsURL = fmt.Sprintf("nats://%s:%s", natsHost, natsPort.Port())
 
 	// Create test credentials for the SYS account
 	// For test containers, we can use empty credentials since auth is not required


### PR DESCRIPTION
## Summary
Fixes incorrect `nats` CLI architecture in multi-platform Docker builds: the builder stage runs on the host platform while the app is built for `TARGETOS`/`TARGETARCH`, so `go install` previously produced a binary for the builder, leading to exec format errors on e.g. arm64 images built on amd64.
## Changes
- **Dockerfile**: Cross-compile the NATS CLI with `GOOS`/`GOARCH` aligned to the image target, resolve `go install` output path (`${GOOS}_${GOARCH}` vs flat `bin/nats`), and copy a single known path into the final image.
- **Helm** (`values.yaml`): Mount a writable `emptyDir` at `/tmp` by default so NATS credential temp files work with `readOnlyRootFilesystem`.
- **Makefile**: `make run` passes `--transport stdio` explicitly.
- **README**: Correct example `NATS_URL` port (`4222`) and JSON formatting.
- **Tests**: Add transport integration tests (streamable HTTP, SSE, stdio) against a real NATS testcontainer; fix NATS URL in account tests by using `Port.Port()` instead of `nat.Port.String()` (avoids `.../tcp` in the URL).
## Testing
- `go test ./...` (integration tests require Docker where applicable).