### PR TITLE
Update version to 0.1.4 across all relevant files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mcp-nats
-[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en/install-mcp?name=NATS&config=eyJjb21tYW5kIjoiZG9ja2VyIHJ1biAtaSAtLXJtIC0taW5pdCAtZSBOQVRTX1VSTCAtZSBOQVRTX05PX0FVVEhFTlRJQ0FUSU9OIGNuYWRiL21jcC1uYXRzIC0tdHJhbnNwb3J0IHN0ZGlvIiwiZW52Ijp7Ik5BVFNfVVJMIjoibmF0czovL2xvY2FsaG9zdDo0MjIyIiwiTkFUU19OT19BVVRIRU5USUNBVElPTiI6InRydWUifX0%3D)
-[<img alt="Install in VS Code" src="https://img.shields.io/badge/Install%20in%20VS%20Code-007ACC?style=for-the-badge&logo=visualstudiocode&logoColor=white&labelColor=007ACC&color=white&logoWidth=24&logoPadding=8">](https://insiders.vscode.dev/redirect?url=vscode%3Amcp%2Finstall%3F%7B%22name%22%3A%22NATS%22%2C%22command%22%3A%22docker%22%2C%22args%22%3A%5B%22run%22%2C%22-i%22%2C%22--rm%22%2C%22--init%22%2C%22-e%22%2C%22NATS_URL%22%2C%22-e%22%2C%22NATS_NO_AUTHENTICATION%22%2C%22cnadb%2Fmcp-nats%22%2C%22--transport%22%2C%22stdio%22%5D%2C%22env%22%3A%7B%22NATS_URL%22%3A%22nats%3A%2F%2Flocalhost%3A4222%22%2C%22NATS_NO_AUTHENTICATION%22%3A%22true%22%7D%7D)
+[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en/install-mcp?name=NATS&config=eyJjb21tYW5kIjoiZG9ja2VyIHJ1biAtaSAtLXJtIC0taW5pdCAtZSBOQVRTX1VSTCAtZSBOQVRTX05PX0FVVEhFTlRJQ0FUSU9OIGdoY3IuaW8vc2luYWRhcmJvdXkvbWNwLW5hdHM6MC4xLjQgLS10cmFuc3BvcnQgc3RkaW8iLCJlbnYiOnsiTkFUU19VUkwiOiJuYXRzOi8vbG9jYWxob3N0OjQyMjIiLCJOQVRTX05PX0FVVEhFTlRJQ0FUSU9OIjoidHJ1ZSJ9fQ%3D%3D)
+[<img alt="Install in VS Code" src="https://img.shields.io/badge/Install%20in%20VS%20Code-007ACC?style=for-the-badge&logo=visualstudiocode&logoColor=white&labelColor=007ACC&color=white&logoWidth=24&logoPadding=8">](https://insiders.vscode.dev/redirect?url=vscode%3Amcp%2Finstall%3F%7B%22name%22%3A%22NATS%22%2C%22command%22%3A%22docker%22%2C%22args%22%3A%5B%22run%22%2C%22-i%22%2C%22--rm%22%2C%22--init%22%2C%22-e%22%2C%22NATS_URL%22%2C%22-e%22%2C%22NATS_NO_AUTHENTICATION%22%2C%22ghcr.io%2Fsinadarbouy%2Fmcp-nats%3A0.1.4%22%2C%22--transport%22%2C%22stdio%22%5D%2C%22env%22%3A%7B%22NATS_URL%22%3A%22nats%3A%2F%2Flocalhost%3A4222%22%2C%22NATS_NO_AUTHENTICATION%22%3A%22true%22%7D%7D)
 
 
 A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for [NATS](https://nats.io/) messaging system integration
@@ -96,7 +96,7 @@ helm install mcp-nats ./deploy/charts/mcp-nats --namespace mcp-nats --create-nam
 Published releases are also installable from OCI, for example:
 
 ```sh
-helm install mcp-nats oci://ghcr.io/sinadarbouy/charts/mcp-nats --version "0.1.0" --namespace mcp-nats --create-namespace
+helm install mcp-nats oci://ghcr.io/sinadarbouy/charts/mcp-nats --version "0.1.4" --namespace mcp-nats --create-namespace
 ```
 
 See the chart README for `Chart.yaml` dependency snippets and registry login.
@@ -348,7 +348,7 @@ If using the binary:
         "NATS_URL",
         "-e",
         "NATS_SYS_CREDS",
-        "cnadb/mcp-nats",
+        "ghcr.io/sinadarbouy/mcp-nats:0.1.4",
         "--transport",
         "stdio"
       ],

--- a/cmd/mcp-nats/main.go
+++ b/cmd/mcp-nats/main.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	// Version of the application
-	Version = "0.1.0"
+	Version = "0.1.4"
 	// AppName is the name of the application
 	AppName = "mcp-nats"
 )

--- a/deploy/charts/mcp-nats/Chart.yaml
+++ b/deploy/charts/mcp-nats/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-nats
 description: MCP server for NATS messaging system.
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.1.4
+appVersion: "0.1.4"
 kubeVersion: "^1.25.0-0"
 home: https://github.com/sinadarbouy/mcp-nats
 sources:

--- a/deploy/charts/mcp-nats/README.md
+++ b/deploy/charts/mcp-nats/README.md
@@ -33,7 +33,7 @@ helm upgrade --install mcp-nats . --namespace mcp-nats -f my-values.yaml
 
 Tagged releases publish this chart to **GHCR** (see the repository [release workflow](https://github.com/sinadarbouy/mcp-nats/blob/main/.github/workflows/release.yml)). The OCI registry path is `oci://ghcr.io/sinadarbouy/charts`; the chart artifact name is **`mcp-nats`**.
 
-Set **`version`** to the chart version you want (it must match a published tag’s chart, for example `0.1.0`).
+Set **`version`** to the chart version you want (it must match a published tag’s chart, for example `0.1.4`).
 
 **Direct install / upgrade**
 
@@ -42,17 +42,17 @@ Set **`version`** to the chart version you want (it must match a published tag�
 helm registry login ghcr.io
 
 helm install mcp-nats oci://ghcr.io/sinadarbouy/charts/mcp-nats \
-  --version "0.1.0" \
+  --version "0.1.4" \
   --namespace mcp-nats \
   --create-namespace
 
 helm upgrade --install mcp-nats oci://ghcr.io/sinadarbouy/charts/mcp-nats \
-  --version "0.1.0" \
+  --version "0.1.4" \
   --namespace mcp-nats \
   -f my-values.yaml
 ```
 
-Default [values.yaml](values.yaml) uses the Docker Hub image `cnadb/mcp-nats`. Releases built from this repo also publish **`ghcr.io/sinadarbouy/mcp-nats`** with the same version tag as the chart; override `image.repository` / `image.tag` if you want the GitHub-built image to match your chart version.
+Default [values.yaml](values.yaml) points at **`ghcr.io/sinadarbouy/mcp-nats`** with a tag matching chart **`appVersion`**. Override `image.registry`, `image.repository`, or `image.tag` if you use a different registry or pin another digest.
 
 **As a dependency of another chart**
 
@@ -64,7 +64,7 @@ name: my-platform
 version: 0.1.0
 dependencies:
   - name: mcp-nats
-    version: "0.1.0"
+    version: "0.1.4"
     repository: "oci://ghcr.io/sinadarbouy/charts"
 ```
 
@@ -81,7 +81,7 @@ Helm resolves `name: mcp-nats` against that OCI repository (chart URL becomes `o
 
 | Area | Values keys | Notes |
 |------|-------------|--------|
-| Image | `image.repository`, `image.tag`, `image.registry`, `image.pullPolicy` | Default image is `cnadb/mcp-nats`; `tag` defaults to chart `appVersion` when empty. |
+| Image | `image.repository`, `image.tag`, `image.registry`, `image.pullPolicy` | Default is **`ghcr.io/sinadarbouy/mcp-nats`**; `tag` defaults to chart `appVersion` when empty. |
 | MCP HTTP | `server.transport`, `server.address`, `server.endpointPath`, `containerPort`, `service.*` | Default transport is `streamable-http` on port **8000**, path **`/mcp`**. |
 | NATS | `nats.url`, `nats.noAuthentication` | Sets `NATS_URL` and `NATS_NO_AUTHENTICATION` on the pod. |
 | User/password auth | `auth.existingSecret`, `auth.createSecret` / `auth.secretData` | When `nats.noAuthentication` is `false`, use an existing Secret or let the chart create one. |

--- a/deploy/charts/mcp-nats/values.yaml
+++ b/deploy/charts/mcp-nats/values.yaml
@@ -9,9 +9,9 @@ deploymentStrategy:
 revisionHistoryLimit: 10
 
 image:
-  registry: ""
-  repository: cnadb/mcp-nats
-  tag: ""
+  registry: "ghcr.io"
+  repository: sinadarbouy/mcp-nats
+  tag: "0.1.4"
   pullPolicy: IfNotPresent
 
 global:


### PR DESCRIPTION
- Updated the application version in main.go to 0.1.4.
- Revised Chart.yaml and associated README files to reflect the new chart version.
- Changed default image repository in values.yaml to point to the new GitHub container registry image.
- Updated installation commands in README.md to use the new version.